### PR TITLE
Feature/app name in main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simply add the starter and you can visit `/fire-starter/` on your application an
 <dependency>
     <groupId>org.axonframework.firestarter</groupId>
     <artifactId>firestarter-spring-starter</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2</version>
 </dependency>
 ```
 

--- a/core/src/main/java/org/axonframework/firestarter/FireStarterHandlerEnhancerDefinition.kt
+++ b/core/src/main/java/org/axonframework/firestarter/FireStarterHandlerEnhancerDefinition.kt
@@ -9,12 +9,14 @@ import org.axonframework.messaging.annotation.MessageHandlingMember
 import org.axonframework.messaging.annotation.WrappedMessageHandlingMember
 import org.axonframework.queryhandling.QueryMessage
 
-class FireStarterHandlerEnhancerDefinition : HandlerEnhancerDefinition {
+class FireStarterHandlerEnhancerDefinition(
+    private val settingsHolder: FireStarterSettingsHolder,
+) : HandlerEnhancerDefinition {
     override fun <T : Any?> wrapHandler(p0: MessageHandlingMember<T>): MessageHandlingMember<T> {
         if (p0.canHandleMessageType(QueryMessage::class.java)) {
             return object : WrappedMessageHandlingMember<T>(p0) {
                 override fun handle(message: Message<*>, target: T?): Any? {
-                    FireStarterSettingsHolder.getSettings().query?.handlers?.applyTaints()
+                    settingsHolder.getSettings().query?.handlers?.applyTaints()
                     return super.handle(message, target)
                 }
             }
@@ -26,7 +28,7 @@ class FireStarterHandlerEnhancerDefinition : HandlerEnhancerDefinition {
             }
             return object : WrappedMessageHandlingMember<T>(p0) {
                 override fun handle(message: Message<*>, target: T?): Any? {
-                    FireStarterSettingsHolder.getSettings().events?.handlers?.applyTaints()
+                    settingsHolder.getSettings().events?.handlers?.applyTaints()
                     return super.handle(message, target)
                 }
             }
@@ -34,7 +36,7 @@ class FireStarterHandlerEnhancerDefinition : HandlerEnhancerDefinition {
         if (p0.canHandleMessageType(CommandMessage::class.java) || p0.canHandleMessageType(DeadlineMessage::class.java)) {
             return object : WrappedMessageHandlingMember<T>(p0) {
                 override fun handle(message: Message<*>, target: T?): Any? {
-                    FireStarterSettingsHolder.getSettings().command?.handlers?.applyTaints()
+                    settingsHolder.getSettings().command?.handlers?.applyTaints()
                     return super.handle(message, target)
                 }
             }

--- a/core/src/main/java/org/axonframework/firestarter/FireStarterSettings.kt
+++ b/core/src/main/java/org/axonframework/firestarter/FireStarterSettings.kt
@@ -17,6 +17,7 @@
 package org.axonframework.firestarter
 
 data class FireStarterSettings(
+    val applicationName: String?,
     val events: EventStoreSettings? = EventStoreSettings(),
     val command: CommandSettings? = CommandSettings(),
     val query: QuerySettings? = QuerySettings(),

--- a/core/src/main/java/org/axonframework/firestarter/FireStarterSettingsHolder.kt
+++ b/core/src/main/java/org/axonframework/firestarter/FireStarterSettingsHolder.kt
@@ -18,7 +18,8 @@ package org.axonframework.firestarter
 
 class FireStarterSettingsHolder {
     companion object {
-        private var settings: FireStarterSettings = FireStarterSettings()
+        private var settings: FireStarterSettings =
+            FireStarterSettings(applicationName = System.getProperty("LOGGED_APPLICATION_NAME"))
 
         @JvmStatic
         fun getSettings(): FireStarterSettings {

--- a/core/src/main/java/org/axonframework/firestarter/FireStarterSettingsHolder.kt
+++ b/core/src/main/java/org/axonframework/firestarter/FireStarterSettingsHolder.kt
@@ -16,19 +16,17 @@
 
 package org.axonframework.firestarter
 
-class FireStarterSettingsHolder {
-    companion object {
-        private var settings: FireStarterSettings =
-            FireStarterSettings(applicationName = System.getProperty("LOGGED_APPLICATION_NAME"))
+class FireStarterSettingsHolder(
+    applicationName: String? = System.getProperty("LOGGED_APPLICATION_NAME")
+) {
+    private var settings: FireStarterSettings =
+        FireStarterSettings(applicationName = applicationName)
 
-        @JvmStatic
-        fun getSettings(): FireStarterSettings {
-            return settings
-        }
+    fun getSettings(): FireStarterSettings {
+        return settings
+    }
 
-        @JvmStatic
-        fun setSettings(settings: FireStarterSettings) {
-            this.settings = settings
-        }
+    fun setSettings(settings: FireStarterSettings) {
+        this.settings = settings.copy(applicationName = this.settings.applicationName)
     }
 }

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterCommandBus.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterCommandBus.kt
@@ -9,7 +9,10 @@ import org.axonframework.messaging.MessageDispatchInterceptor
 import org.axonframework.messaging.MessageHandler
 import org.axonframework.messaging.MessageHandlerInterceptor
 
-class FireStarterCommandBus(private val delegate: CommandBus) : CommandBus {
+class FireStarterCommandBus(
+    private val delegate: CommandBus,
+    private val settingsHolder: FireStarterSettingsHolder,
+) : CommandBus {
     override fun registerHandlerInterceptor(handlerInterceptor: MessageHandlerInterceptor<in CommandMessage<*>>): Registration? {
         return delegate.registerHandlerInterceptor(handlerInterceptor)
     }
@@ -23,7 +26,7 @@ class FireStarterCommandBus(private val delegate: CommandBus) : CommandBus {
     }
 
     override fun <C : Any?, R : Any?> dispatch(command: CommandMessage<C>, callback: CommandCallback<in C, in R>) {
-        FireStarterSettingsHolder.getSettings().command?.dispatch?.applyTaints()
+        settingsHolder.getSettings().command?.dispatch?.applyTaints()
         return delegate.dispatch(command, callback)
     }
 

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterLockFactory.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterLockFactory.kt
@@ -20,9 +20,12 @@ import org.axonframework.common.lock.Lock
 import org.axonframework.common.lock.LockFactory
 import org.axonframework.firestarter.FireStarterSettingsHolder
 
-class FireStarterLockFactory(private val lockFactory: LockFactory): LockFactory {
+class FireStarterLockFactory(
+    private val lockFactory: LockFactory,
+    private val settingsHolder: FireStarterSettingsHolder,
+) : LockFactory {
     override fun obtainLock(identifier: String?): Lock? {
-        FireStarterSettingsHolder.getSettings().command?.lockTime?.applyTaints()
+        settingsHolder.getSettings().command?.lockTime?.applyTaints()
         return lockFactory.obtainLock(identifier)
     }
 }

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterQueryBus.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterQueryBus.kt
@@ -27,7 +27,10 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
 
-class FireStarterQueryBus(private val delegate: QueryBus) : QueryBus {
+class FireStarterQueryBus(
+    private val delegate: QueryBus,
+    private val settingsHolder: FireStarterSettingsHolder,
+) : QueryBus {
     override fun registerHandlerInterceptor(handlerInterceptor: MessageHandlerInterceptor<in QueryMessage<*, *>>): Registration? {
         return delegate.registerHandlerInterceptor(handlerInterceptor)
     }
@@ -45,7 +48,7 @@ class FireStarterQueryBus(private val delegate: QueryBus) : QueryBus {
     }
 
     override fun <Q : Any?, R : Any?> query(query: QueryMessage<Q, R>): CompletableFuture<QueryResponseMessage<R>> {
-        return CompletableFuture.runAsync { FireStarterSettingsHolder.getSettings().query?.dispatch?.applyTaints() }
+        return CompletableFuture.runAsync { settingsHolder.getSettings().query?.dispatch?.applyTaints() }
             .thenCompose { delegate.query(query) }
     }
 
@@ -54,7 +57,7 @@ class FireStarterQueryBus(private val delegate: QueryBus) : QueryBus {
         timeout: Long,
         unit: TimeUnit
     ): Stream<QueryResponseMessage<R>>? {
-        FireStarterSettingsHolder.getSettings().query?.dispatch?.applyTaints()
+        settingsHolder.getSettings().query?.dispatch?.applyTaints()
         return delegate.scatterGather(query, timeout, unit)
     }
 

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterRepository.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterRepository.kt
@@ -8,8 +8,11 @@ import org.axonframework.modelling.command.Repository
 import java.util.concurrent.Callable
 import java.util.function.Consumer
 
-class FireStarterRepository<T>(private val delegate: Repository<T>) :
-        Repository<T> {
+class FireStarterRepository<T>(
+    private val delegate: Repository<T>,
+    private val settingsHolder: FireStarterSettingsHolder,
+) :
+    Repository<T> {
     override fun send(message: Message<*>?, scopeDescription: ScopeDescriptor?) {
         return delegate.send(message, scopeDescription)
     }
@@ -19,12 +22,12 @@ class FireStarterRepository<T>(private val delegate: Repository<T>) :
     }
 
     override fun load(p0: String): Aggregate<T>? {
-        FireStarterSettingsHolder.getSettings().command?.repositoryLoad?.applyTaints()
+        settingsHolder.getSettings().command?.repositoryLoad?.applyTaints()
         return delegate.load(p0)
     }
 
     override fun load(p0: String, p1: Long?): Aggregate<T>? {
-        FireStarterSettingsHolder.getSettings().command?.repositoryLoad?.applyTaints()
+        settingsHolder.getSettings().command?.repositoryLoad?.applyTaints()
         return delegate.load(p0, p1)
 
     }

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterSagaRepository.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterSagaRepository.kt
@@ -5,14 +5,17 @@ import org.axonframework.modelling.saga.AssociationValue
 import org.axonframework.modelling.saga.AssociationValues
 import org.axonframework.modelling.saga.repository.SagaStore
 
-class FireStarterSagaStore<T>(private val delegate: SagaStore<T>) : SagaStore<T> {
+class FireStarterSagaStore<T>(
+    private val delegate: SagaStore<T>,
+    private val settingsHolder: FireStarterSettingsHolder,
+) : SagaStore<T> {
     override fun findSagas(sagaType: Class<out T>?, associationValue: AssociationValue?): MutableSet<String>? {
-        FireStarterSettingsHolder.getSettings().sagas?.retrieve?.applyTaints()
+        settingsHolder.getSettings().sagas?.retrieve?.applyTaints()
         return delegate.findSagas(sagaType, associationValue)
     }
 
     override fun <S : T> loadSaga(sagaType: Class<S>?, sagaIdentifier: String?): SagaStore.Entry<S>? {
-        FireStarterSettingsHolder.getSettings().sagas?.retrieve?.applyTaints()
+        settingsHolder.getSettings().sagas?.retrieve?.applyTaints()
         return delegate.loadSaga(sagaType, sagaIdentifier)
     }
 
@@ -21,7 +24,7 @@ class FireStarterSagaStore<T>(private val delegate: SagaStore<T>) : SagaStore<T>
         sagaIdentifier: String?,
         associationValues: MutableSet<AssociationValue>?
     ) {
-        FireStarterSettingsHolder.getSettings().sagas?.delete?.applyTaints()
+        settingsHolder.getSettings().sagas?.delete?.applyTaints()
         delegate.deleteSaga(sagaType, sagaIdentifier, associationValues)
     }
 
@@ -31,7 +34,7 @@ class FireStarterSagaStore<T>(private val delegate: SagaStore<T>) : SagaStore<T>
         saga: T,
         associationValues: MutableSet<AssociationValue>?
     ) {
-        FireStarterSettingsHolder.getSettings().sagas?.create?.applyTaints()
+        settingsHolder.getSettings().sagas?.create?.applyTaints()
         delegate.insertSaga(sagaType, sagaIdentifier, saga, associationValues)
     }
 
@@ -41,7 +44,7 @@ class FireStarterSagaStore<T>(private val delegate: SagaStore<T>) : SagaStore<T>
         saga: T,
         associationValues: AssociationValues?
     ) {
-        FireStarterSettingsHolder.getSettings().sagas?.update?.applyTaints()
+        settingsHolder.getSettings().sagas?.update?.applyTaints()
         delegate.updateSaga(sagaType, sagaIdentifier, saga, associationValues)
     }
 

--- a/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterTokenStore.kt
+++ b/core/src/main/java/org/axonframework/firestarter/decorators/FireStarterTokenStore.kt
@@ -25,11 +25,14 @@ import org.axonframework.eventhandling.tokenstore.UnableToRetrieveIdentifierExce
 import org.axonframework.firestarter.FireStarterSettingsHolder
 import java.util.*
 
-class FireStarterTokenStore(private val delegate: TokenStore) : TokenStore {
+class FireStarterTokenStore(
+    private val delegate: TokenStore,
+    private val settingsHolder: FireStarterSettingsHolder,
+) : TokenStore {
 
     @Throws(UnableToClaimTokenException::class)
     override fun initializeTokenSegments(processorName: String, segmentCount: Int) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.initializeTokenSegments(processorName, segmentCount)
     }
 
@@ -39,17 +42,17 @@ class FireStarterTokenStore(private val delegate: TokenStore) : TokenStore {
         segmentCount: Int,
         initialToken: TrackingToken?
     ) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.initializeTokenSegments(processorName, segmentCount, initialToken)
     }
 
     override fun storeToken(token: TrackingToken?, processorName: String, segment: Int) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.storeToken(token, processorName, segment)
     }
 
     override fun fetchToken(processorName: String, segement: Int): TrackingToken? {
-        FireStarterSettingsHolder.getSettings().tokens?.fetch?.applyTaints()
+        settingsHolder.getSettings().tokens?.fetch?.applyTaints()
         return delegate.fetchToken(processorName, segement)
     }
 
@@ -57,24 +60,24 @@ class FireStarterTokenStore(private val delegate: TokenStore) : TokenStore {
     override fun fetchToken(
         processorName: String, segment: Segment
     ): TrackingToken? {
-        FireStarterSettingsHolder.getSettings().tokens?.fetch?.applyTaints()
+        settingsHolder.getSettings().tokens?.fetch?.applyTaints()
         return delegate.fetchToken(processorName, segment.segmentId)
     }
 
     @Throws(UnableToClaimTokenException::class)
     override fun extendClaim(processorName: String, segment: Int) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.extendClaim(processorName, segment)
     }
 
     override fun releaseClaim(processorName: String, segment: Int) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.releaseClaim(processorName, segment)
     }
 
     @Throws(UnableToInitializeTokenException::class)
     override fun initializeSegment(token: TrackingToken?, processorName: String, segment: Int) {
-        FireStarterSettingsHolder.getSettings().tokens?.store?.applyTaints()
+        settingsHolder.getSettings().tokens?.store?.applyTaints()
         delegate.initializeSegment(token, processorName, segment)
     }
 
@@ -88,12 +91,12 @@ class FireStarterTokenStore(private val delegate: TokenStore) : TokenStore {
     }
 
     override fun fetchSegments(processorName: String): IntArray? {
-        FireStarterSettingsHolder.getSettings().tokens?.fetch?.applyTaints()
+        settingsHolder.getSettings().tokens?.fetch?.applyTaints()
         return delegate.fetchSegments(processorName)
     }
 
     override fun fetchAvailableSegments(processorName: String): List<Segment?>? {
-        FireStarterSettingsHolder.getSettings().tokens?.fetch?.applyTaints()
+        settingsHolder.getSettings().tokens?.fetch?.applyTaints()
         return delegate.fetchAvailableSegments(processorName)
     }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,7 +33,7 @@ const save = async () => {
     <nav class="navbar navbar-expand-lg navbar-light bg-white">
       <div class="container-fluid px-3">
         <a class="navbar-brand" href="/"><img src="./assets/logo.svg" alt="" width="30" height="24"> AxonFramework
-          FireStarter</a>
+          FireStarter {{ settings.applicationName }}</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>

--- a/starter/src/main/java/org/axonframework/firestarter/FireStarterBeanPostProcessor.kt
+++ b/starter/src/main/java/org/axonframework/firestarter/FireStarterBeanPostProcessor.kt
@@ -22,11 +22,12 @@ import org.axonframework.eventsourcing.eventstore.EventStore
 import org.axonframework.firestarter.decorators.*
 import org.axonframework.modelling.saga.repository.SagaStore
 import org.axonframework.queryhandling.QueryBus
-import org.axonframework.tracing.SpanFactory
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.config.BeanPostProcessor
 
-class FireStarterBeanPostProcessor: BeanPostProcessor {
+class FireStarterBeanPostProcessor(
+    private val settingsHolder: FireStarterSettingsHolder,
+) : BeanPostProcessor {
     private val logger = LoggerFactory.getLogger(
         this::class.java
     )
@@ -34,23 +35,23 @@ class FireStarterBeanPostProcessor: BeanPostProcessor {
     override fun postProcessBeforeInitialization(bean: Any, beanName: String): Any? {
         if (bean is EventStore) {
             logger.info("Decorating EventStore with Axon Framework Firestarter")
-            return FireStarterEventStore(bean)
+            return FireStarterEventStore(bean, settingsHolder)
         }
         if (bean is QueryBus) {
             logger.info("Decorating QueryBus with Axon Framework Firestarter")
-            return FireStarterQueryBus(bean)
+            return FireStarterQueryBus(bean, settingsHolder)
         }
         if (bean is CommandBus) {
             logger.info("Decorating CommandBus with Axon Framework Firestarter")
-            return FireStarterCommandBus(bean)
+            return FireStarterCommandBus(bean, settingsHolder)
         }
         if (bean is SagaStore<*>) {
             logger.info("Decorating SagaRepository with Axon Framework Firestarter")
-            return FireStarterSagaStore(bean)
+            return FireStarterSagaStore(bean, settingsHolder)
         }
         if (bean is TokenStore) {
             logger.info("Decorating TokenStore with Axon Framework Firestarter")
-            return FireStarterTokenStore(bean)
+            return FireStarterTokenStore(bean, settingsHolder)
         }
         return super.postProcessBeforeInitialization(bean, beanName)
     }

--- a/starter/src/main/java/org/axonframework/firestarter/FireStarterConfiguration.kt
+++ b/starter/src/main/java/org/axonframework/firestarter/FireStarterConfiguration.kt
@@ -24,45 +24,72 @@ import org.axonframework.config.ConfigurerModule
 import org.axonframework.firestarter.decorators.FireStarterLockFactory
 import org.axonframework.firestarter.decorators.FireStarterRepository
 import org.axonframework.modelling.command.Repository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class FireStarterConfiguration {
     @Bean
-    fun fireStarterBeanPostProcessor() = FireStarterBeanPostProcessor()
+    fun fireStarterSettingsHolder(
+        @Value("\${spring.application.name:}") nameProperty: String?,
+        applicationContext: ApplicationContext,
+    ): FireStarterSettingsHolder {
+        // Determine the name. First, name property, then spring application name, then context name
+        // This should always result in a sane value
+        val applicationName = (nameProperty?.trim()?.ifEmpty { null })
+            ?: (applicationContext.applicationName.trim().ifEmpty { null })
+            ?: (applicationContext.id?.removeSuffix("-1"))
+            ?: "Unknown application"
+        return FireStarterSettingsHolder(applicationName)
+    }
 
     @Bean
-    fun fireStarterController() = FireStarterController()
+    fun fireStarterBeanPostProcessor(settingsHolder: FireStarterSettingsHolder): FireStarterBeanPostProcessor {
+        return FireStarterBeanPostProcessor(settingsHolder)
+    }
 
     @Bean
-    fun fireStarterHandlerEnhancerDefinition() = FireStarterHandlerEnhancerDefinition()
+    fun fireStarterController(settingsHolder: FireStarterSettingsHolder): FireStarterController {
+        return FireStarterController(settingsHolder)
+    }
 
     @Bean
-    fun fireStarterConfigurerModule() = ConfigurerModule { configurer ->
+    fun fireStarterHandlerEnhancerDefinition(settingsHolder: FireStarterSettingsHolder): FireStarterHandlerEnhancerDefinition {
+        return FireStarterHandlerEnhancerDefinition(settingsHolder)
+    }
 
-        configurer.onInitialize { config ->
-            config.findModules(AggregateConfiguration::class.java).forEach { ac ->
-                val field = ac::class.java.declaredFields.first { it.name === "repository" }
-                val current = ReflectionUtils.getFieldValue<Component<Repository<*>>>(field, ac)
+    @Bean
+    fun fireStarterConfigurerModule(settingsHolder: FireStarterSettingsHolder): ConfigurerModule {
+        return ConfigurerModule { configurer ->
+            configurer.onInitialize { config ->
+                config.findModules(AggregateConfiguration::class.java).forEach { ac ->
+                    val field = ac::class.java.declaredFields.first { it.name === "repository" }
+                    val current = ReflectionUtils.getFieldValue<Component<Repository<*>>>(field, ac)
 
-                ReflectionUtils.setFieldValue(
+                    ReflectionUtils.setFieldValue(
                         field,
                         ac,
                         Component<Repository<*>>(
-                                { config },
-                                "Repository",
-                                { c ->
-                                    val currentRepo = current.get()
-                                    current::class.java.declaredFields.firstOrNull { it.name === "lockFactory" }?.let {
-                                        val delegate = ReflectionUtils.getFieldValue<LockFactory>(it, currentRepo)
-                                        ReflectionUtils.setFieldValue(it, currentRepo, FireStarterLockFactory(delegate))
-                                    }
-                                    FireStarterRepository(currentRepo)
-                                }),
-                )
-            }
+                            { config },
+                            "Repository",
+                            { c ->
+                                val currentRepo = current.get()
+                                current::class.java.declaredFields.firstOrNull { it.name === "lockFactory" }?.let {
+                                    val delegate = ReflectionUtils.getFieldValue<LockFactory>(it, currentRepo)
+                                    ReflectionUtils.setFieldValue(
+                                        it,
+                                        currentRepo,
+                                        FireStarterLockFactory(delegate, settingsHolder)
+                                    )
+                                }
+                                FireStarterRepository(currentRepo, settingsHolder)
+                            }),
+                    )
+                }
 
+            }
         }
     }
 }

--- a/starter/src/main/java/org/axonframework/firestarter/FireStarterController.kt
+++ b/starter/src/main/java/org/axonframework/firestarter/FireStarterController.kt
@@ -4,16 +4,14 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.util.ResourceUtils
 import org.springframework.util.StreamUtils
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.*
 import java.nio.charset.Charset
 
 @Controller
 @RequestMapping("fire-starter")
-class FireStarterController {
+class FireStarterController(
+    private val settingsHolder: FireStarterSettingsHolder,
+) {
     @GetMapping(value = ["/"], produces = ["text/html"])
     @ResponseBody
     fun serveFrontend(): String {
@@ -23,12 +21,12 @@ class FireStarterController {
 
     @PostMapping("settings")
     fun setConfig(@RequestBody settings: FireStarterSettings): ResponseEntity<String> {
-        FireStarterSettingsHolder.setSettings(settings)
+        settingsHolder.setSettings(settings)
         return ResponseEntity.accepted().build()
     }
 
     @GetMapping("settings", produces = ["application/json"])
     fun getConfig(): ResponseEntity<FireStarterSettings> {
-        return ResponseEntity.ok(FireStarterSettingsHolder.getSettings())
+        return ResponseEntity.ok(settingsHolder.getSettings())
     }
 }


### PR DESCRIPTION
The Fire-starte page now shows the `LOGGED_APPLICATION_NAME` to help identify the fire starter and the application that it's linked to. (Useful when there are several microservices with the firestarter configured).

![image](https://github.com/AxonFramework/AxonFramework-FireStarter/assets/1894346/7eb39275-f61c-4769-aaf9-899e6a9afbd3)

The application name is added to the settings:

![image](https://github.com/AxonFramework/AxonFramework-FireStarter/assets/1894346/f1b7a93c-9b73-4972-9c3c-e9377f96a75f)
